### PR TITLE
In stdin mode, when _id (or id) is available in the document, use it for indexing

### DIFF
--- a/src/stream2es/stream/stdin.clj
+++ b/src/stream2es/stream/stdin.clj
@@ -51,4 +51,8 @@
 (extend-type String
   Streamable
   (make-source [doc opts]
-    (json/decode doc true)))
+    (let [{:keys [_id id] :as document} (json/decode doc true)]
+      ;; if an id is available, the capture it
+      (if-let [doc-id (or _id id)]
+        (merge document {:__s2e_meta__ {:_id doc-id}})
+        document))))


### PR DESCRIPTION
Currently the `stdin` mode, doesn't support `id`. If the same file is streamed twice the documents will be duplicated in the index with auto-generated ids. This change allows `stream2es` to use the field `_id` or `id` when available in the streamed document for indexing purposes avoiding duplicates.