### PR TITLE
add options that allow for more accurate index migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ pom.xml.asc
 .lein-repl-history
 /tmp
 /.nrepl-port
+
+# intellij / cursive ignore
+.idea
+*.iml

--- a/src/stream2es/opts.clj
+++ b/src/stream2es/opts.clj
@@ -28,6 +28,8 @@
    ["-w" "--workers" "Number of indexing threads"
     :default indexing-threads
     :parse-fn #(Integer/parseInt %)]
+   ["--clobber" "Use elasticsearch 'index' operation, clobbering existing documents, no-clobber uses 'create' which will skip/error existing documents" :flag true :default false]
+   ["--tee-errors" "Create error-{id} files" :flag true :default true]
    ["--tee" "Save json request payloads as files in path"]
    ["--tee-bulk" "Save bulk request payloads as files in path"]
    ["--mappings" "Index mappings" :default nil]


### PR DESCRIPTION
* When migrating indexes, one will usually enable dual writes and then
begin a stream2es to stream old index data to the new index. In this
scenario, if a new write has written a document before stream2es attempts
to write it, we'd rather the write error and be skipped. This commit allows
us to use the `create` operation to avoid overwriting existing documents with the
`-no-clobber` flag.
* When using this option, many `error-*` documents would be created, allow disabling
the creation of these with the --no-tee-errors flag
* Fix an issue where error counts were not properly being tracked because the error-count
was being nil'd out before being added to the state
* Fix an issue where the trace log in `index-bulk` reported innacurate results

**This will change the following default behavior**:
* In order to avoid clobbering existing data, stream2es defaults to using the `create` operation now.